### PR TITLE
fix(ci): repair YAML block-scalar in workflow-linter Check Permissions step

### DIFF
--- a/.github/workflows/workflow-linter.yml
+++ b/.github/workflows/workflow-linter.yml
@@ -54,8 +54,8 @@ jobs:
             fi
           done
           if [ $failed -eq 1 ]; then
-            echo "Add 'permissions:
-  contents: read' at workflow level"
+            echo "Add 'permissions:'"
+            echo "  contents: read' at workflow level"
             exit 1
           fi
           echo "All workflows have permissions declared"


### PR DESCRIPTION
`workflow-linter.yml` fails with 0 jobs in 0 seconds because of a YAML block-scalar bug at the "Check Permissions Declaration" step. The `run: |` block contains:

```yaml
            echo "Add 'permissions:
  contents: read' at workflow level"
```

The second line has only 2 spaces of leading indent, which is LESS than the 10-space indent of the `run: |` block scalar. YAML terminates the block at the first line and treats `  contents: read' at workflow level"` as a top-level mapping fragment — making the whole workflow invalid. GitHub Actions then rejects the workflow during validation, completing the run with no jobs spawned.

Mirrors hyperpolymath/stapeln#35 — same regex-targeted fix that replaces the broken 2-line echo with two valid one-line echoes preserving the user-facing message:

```yaml
            echo "Add 'permissions:'"
            echo "  contents: read' at workflow level"
```

After this fix, the Workflow Security Linter actually runs and reports SPDX/permissions/SHA-pin/duplicate findings as designed.