### PR TITLE
fix(ci): move secret-scanner Cargo.toml gate from job-level if: to step-level

### DIFF
--- a/.github/workflows/secret-scanner.yml
+++ b/.github/workflows/secret-scanner.yml
@@ -40,12 +40,15 @@ jobs:
   # Rust-specific: Check for hardcoded crypto values
   rust-secrets:
     runs-on: ubuntu-latest
-    if: hashFiles('**/Cargo.toml') != ''
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
 
       - name: Check for hardcoded secrets in Rust
         run: |
+          if ! find . -name Cargo.toml -not -path './target/*' -print -quit | grep -q .; then
+            echo 'No Cargo.toml found — skipping Rust secrets check'
+            exit 0
+          fi
           # Patterns that suggest hardcoded secrets
           PATTERNS=(
             'const.*SECRET.*=.*"'


### PR DESCRIPTION
`secret-scanner.yml` has had 0 successful runs since creation across all estate consumers — every run completes in 0 seconds with `conclusion=failure` and zero jobs spawned (GitHub Actions startup_failure). YAML is syntactically valid; both action SHAs exist; `gh workflow view` returns the file cleanly.

## Root cause

The `rust-secrets` job has a job-level `if:` clause:

```yaml
  rust-secrets:
    runs-on: ubuntu-latest
    if: hashFiles('**/Cargo.toml') != ''
```

GitHub Actions does not support `hashFiles()` in **job-level** `if:` conditions. The docs say `hashFiles` is "available in the runtime environment when steps are running" — i.e. step-level only. At job-eligibility time the expression evaluator rejects the workflow, no jobs are scheduled, the run is marked as a failed startup. Wrapping in ${{ }} makes no difference.

## Fix

Mirrors hyperpolymath/stapeln#36. Removes the job-level `if:` line and adds a step-level guard at the top of the existing run block:

```bash
if ! find . -name Cargo.toml -not -path './target/*' -print -quit | grep -q .; then
  echo "No Cargo.toml found — skipping Rust secrets check"
  exit 0
fi
```

Same semantics (skip when no `Cargo.toml`), but at a context where the expression works.

After this fix, the Secret Scanner workflow actually runs trufflehog + gitleaks + (conditionally) rust-secrets as designed.