### PR TITLE
fix(ci): adopt canonical hypatia-scan.yml

### DIFF
--- a/.github/workflows/hypatia-scan.yml
+++ b/.github/workflows/hypatia-scan.yml
@@ -10,12 +10,26 @@ on:
   schedule:
     - cron: '0 0 * * 0'  # Weekly on Sunday
   workflow_dispatch:
+# Estate guardrail: cancel superseded runs so re-pushes don't pile up
+# queued runs across the estate. Safe here because this workflow only
+# performs read-only checks/lint/test/scan with no publish or mutation.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read
   # security-events: read lets the built-in GITHUB_TOKEN query this
-  # repo\'s own Dependabot alerts via the Hypatia DependabotAlerts rule.
+  # repo's own Dependabot alerts via the Hypatia DependabotAlerts rule
+  # (DA001-DA004). Without this, `scan_from_path` gets HTTP 403 and
+  # the rule silently returns no findings.
+  # See 007-lang/audits/audit-dependabot-automation-gap-2026-04-17.md.
   security-events: read
+  # pull-requests: write lets the advisory "Comment on PR with findings"
+  # step post its summary. Without it the built-in GITHUB_TOKEN gets
+  # "Resource not accessible by integration" and (absent continue-on-error)
+  # hard-fails the scan — exactly what the gate-decoupling design forbids.
+  pull-requests: write
 
 jobs:
   scan:
@@ -24,7 +38,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0  # Full history for better pattern analysis
 
@@ -41,23 +55,27 @@ jobs:
           fi
 
       - name: Build Hypatia scanner (if needed)
-        working-directory: /home/runner/hypatia
         run: |
-          if [ ! -f hypatia-v2 ]; then
-            echo "Building hypatia-v2 scanner..."
-            cd scanner
+          cd "$HOME/hypatia"
+          if [ ! -f hypatia ]; then
+            echo "Building hypatia scanner..."
             mix deps.get
             mix escript.build
-            mv hypatia ../hypatia-v2
           fi
 
       - name: Run Hypatia scan
         id: scan
+        env:
+          # Pass the built-in Actions token through to Hypatia so the
+          # DependabotAlerts rule can query this repo's own alerts.
+          # For cross-repo scanning (fleet-coordinator scan-supervised),
+          # a PAT with `security_events` scope is required instead.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           echo "Scanning repository: ${{ github.repository }}"
 
-          # Run scanner
-          HYPATIA_FORMAT=json "$HOME/hypatia/hypatia-cli.sh" scan . > hypatia-findings.json
+          # Run scanner (exits non-zero when findings exist — suppress to continue)
+          HYPATIA_FORMAT=json "$HOME/hypatia/hypatia-cli.sh" scan . --exit-zero > hypatia-findings.json || true
 
           # Count findings
           FINDING_COUNT=$(jq '. | length' hypatia-findings.json 2>/dev/null || echo 0)
@@ -79,7 +97,7 @@ jobs:
           echo "- Medium: $MEDIUM" >> $GITHUB_STEP_SUMMARY
 
       - name: Upload findings artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: hypatia-findings
           path: hypatia-findings.json
@@ -87,24 +105,72 @@ jobs:
 
       - name: Submit findings to gitbot-fleet (Phase 2)
         if: steps.scan.outputs.findings_count > 0
+        # Phase 2 is the collaborative LEARNING side-channel ("bots share
+        # findings via gitbot-fleet"), not the security gate. The gate is
+        # the baseline-aware "Check for critical or high-severity issues"
+        # step below. A fleet-side regression (e.g. the submit script being
+        # moved/removed) must NEVER hard-fail every consuming repo's scan.
+        # Same reasoning as the "Comment on PR with findings" step.
+        # See hyperpolymath/hypatia#213 (gate decoupling) and the exit-127
+        # estate-wide breakage when gitbot-fleet/scripts/submit-finding.sh
+        # no longer existed on the default branch.
+        continue-on-error: true
         env:
+          # All GitHub context values surface as env vars so the run
+          # block never interpolates `${{ … }}` inline (closes the
+          # workflow_audit/unsafe_curl_payload + actions_expression_injection
+          # findings).
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          FLEET_PUSH_TOKEN: ${{ secrets.HYPATIA_DISPATCH_PAT }}
+          FLEET_DISPATCH_TOKEN: ${{ secrets.HYPATIA_DISPATCH_PAT }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           GITHUB_SHA: ${{ github.sha }}
+          FINDINGS_COUNT: ${{ steps.scan.outputs.findings_count }}
         run: |
-          echo "📤 Submitting ${{ steps.scan.outputs.findings_count }} findings to gitbot-fleet..."
+          echo "📤 Submitting $FINDINGS_COUNT findings to gitbot-fleet..."
 
-          # Clone gitbot-fleet to temp directory
+          # Clone gitbot-fleet to temp directory. A clone failure (network,
+          # repo gone) is non-fatal: learning submission is best-effort.
           FLEET_DIR="/tmp/gitbot-fleet-$$"
-          git clone https://github.com/hyperpolymath/gitbot-fleet.git "$FLEET_DIR"
+          if ! git clone --depth 1 https://github.com/hyperpolymath/gitbot-fleet.git "$FLEET_DIR"; then
+            echo "::warning::Could not clone gitbot-fleet — skipping Phase 2 learning submission (non-fatal)."
+            exit 0
+          fi
 
-          # Run submission script
-          bash "$FLEET_DIR/scripts/submit-finding.sh" hypatia-findings.json
+          # The submission script's location in gitbot-fleet has drifted
+          # before (it was absent from the default branch, which exit-127'd
+          # every consuming repo's scan). Probe known locations rather than
+          # hard-coding one path, and skip gracefully if none is present.
+          SUBMIT_SCRIPT=""
+          for cand in \
+            "$FLEET_DIR/scripts/submit-finding.sh" \
+            "$FLEET_DIR/scripts/submit_finding.sh" \
+            "$FLEET_DIR/bin/submit-finding.sh" \
+            "$FLEET_DIR/submit-finding.sh"; do
+            if [ -f "$cand" ]; then
+              SUBMIT_SCRIPT="$cand"
+              break
+            fi
+          done
+
+          if [ -z "$SUBMIT_SCRIPT" ]; then
+            echo "::warning::gitbot-fleet submit-finding script not found at any known path — skipping Phase 2 learning submission (non-fatal). Findings are still uploaded as an artifact and gated below."
+            rm -rf "$FLEET_DIR"
+            exit 0
+          fi
+
+          # Run submission script. Pass the findings path as ABSOLUTE —
+          # the script cd's into its own working dir before reading the
+          # file, so a relative path would resolve to the wrong place.
+          # A submission-script failure is logged but non-fatal.
+          if bash "$SUBMIT_SCRIPT" "$GITHUB_WORKSPACE/hypatia-findings.json"; then
+            echo "✅ Finding submission complete"
+          else
+            echo "::warning::gitbot-fleet submission script exited non-zero — Phase 2 learning submission skipped (non-fatal)."
+          fi
 
           # Cleanup
           rm -rf "$FLEET_DIR"
-
-          echo "✅ Finding submission complete"
 
       - name: Check for critical issues
         if: steps.scan.outputs.critical > 0
@@ -150,7 +216,12 @@ jobs:
 
       - name: Comment on PR with findings
         if: github.event_name == 'pull_request' && steps.scan.outputs.findings_count > 0
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
+        # Advisory only — posting findings as a PR comment must never gate
+        # the scan (hypatia#213 gate decoupling). Belt-and-braces alongside
+        # the pull-requests: write permission above: a token/API hiccup or
+        # a fork PR (read-only token) skips the comment, not the check.
+        continue-on-error: true
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v7
         with:
           script: |
             const fs = require('fs');


### PR DESCRIPTION
Estate sweep (verisimiser#102 cascade): replace drifted hypatia-scan.yml with the fixed canonical — corrects the env.HOME workdir / old scanner layout drift AND adds pull-requests:write + Comment-step continue-on-error so the advisory PR comment never hard-fails the Hypatia check (hypatia#213). Mechanical, verified green on verisimiser main.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>