### PR TITLE
chore(linguist): exclude ReScript from language detection

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -52,3 +52,5 @@ Containerfile  text eol=lf
 # Lock files
 Cargo.lock  text eol=lf -diff
 flake.lock  text eol=lf -diff
+# Pending estate-wide policy: hide ReScript from primary-language detection.
+**/*.res linguist-detectable=false


### PR DESCRIPTION
## Summary
Adds `**/*.res linguist-detectable=false` to `.gitattributes` so ReScript files do not dominate GitHub's primary-language detection.

**Rationale**: Estate-wide policy: ReScript is being migrated to AffineScript. Pending mechanical migration; this PR is the immediate cosmetic fix to stop ReScript dominating GitHub's primary-language detection until the source files are ported.

## Changes
- `.gitattributes`: `**/*.res linguist-detectable=false`

Part of estate-wide metadata cleanup 2026-05-26.